### PR TITLE
Add bit length impls for bool and arrays

### DIFF
--- a/src/bool.rs
+++ b/src/bool.rs
@@ -4,22 +4,6 @@ impl BitLength for bool {
     const BITS: usize = 1;
 }
 
-impl<const N: usize> BitLength for [bool; N] {
-    const BITS: usize = N;
-}
-
-impl<const N: usize> BitLength for &[bool; N] {
-    const BITS: usize = N;
-}
-
 impl BitLength for &bool {
     const BITS: usize = 1;
-}
-
-impl<const N: usize> BitLength for [&bool; N] {
-    const BITS: usize = N;
-}
-
-impl<const N: usize> BitLength for &[&bool; N] {
-    const BITS: usize = N;
 }

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -1,0 +1,25 @@
+use crate::BitLength;
+
+impl BitLength for bool {
+    const BITS: usize = 1;
+}
+
+impl<const N: usize> BitLength for [bool; N] {
+    const BITS: usize = N;
+}
+
+impl<const N: usize> BitLength for &[bool; N] {
+    const BITS: usize = N;
+}
+
+impl BitLength for &bool {
+    const BITS: usize = 1;
+}
+
+impl<const N: usize> BitLength for [&bool; N] {
+    const BITS: usize = N;
+}
+
+impl<const N: usize> BitLength for &[&bool; N] {
+    const BITS: usize = N;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@
 
 #[cfg(feature = "alloc")]
 mod alloc;
+mod bool;
 mod slice;
 mod str;
 mod traits;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -23,6 +23,20 @@ pub trait BitLength {
     const BITS: usize;
 }
 
+impl<const N: usize, T> BitLength for [T; N]
+where
+    T: BitLength,
+{
+    const BITS: usize = N * T::BITS;
+}
+
+impl<const N: usize, T> BitLength for &[T; N]
+where
+    T: BitLength,
+{
+    const BITS: usize = N * T::BITS;
+}
+
 /// Trait for getting a bit at a given index.
 pub trait GetBit<O>
 where

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -49,24 +49,8 @@ macro_rules! impl_get_bit_uint {
             const BITS: usize = <$ty>::BITS as usize;
         }
 
-        impl<const N: usize> BitLength for [$ty; N] {
-            const BITS: usize = N * <$ty>::BITS as usize;
-        }
-
-        impl<const N: usize> BitLength for &[$ty; N] {
-            const BITS: usize = N * <$ty>::BITS as usize;
-        }
-
         impl BitLength for &$ty {
             const BITS: usize = <$ty>::BITS as usize;
-        }
-
-        impl<const N: usize> BitLength for [&$ty; N] {
-            const BITS: usize = N * <$ty>::BITS as usize;
-        }
-
-        impl<const N: usize> BitLength for &[&$ty; N] {
-            const BITS: usize = N * <$ty>::BITS as usize;
         }
 
         impl GetBit<Lsb0> for $ty {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -49,8 +49,24 @@ macro_rules! impl_get_bit_uint {
             const BITS: usize = <$ty>::BITS as usize;
         }
 
+        impl<const N: usize> BitLength for [$ty; N] {
+            const BITS: usize = N * <$ty>::BITS as usize;
+        }
+
+        impl<const N: usize> BitLength for &[$ty; N] {
+            const BITS: usize = N * <$ty>::BITS as usize;
+        }
+
         impl BitLength for &$ty {
             const BITS: usize = <$ty>::BITS as usize;
+        }
+
+        impl<const N: usize> BitLength for [&$ty; N] {
+            const BITS: usize = N * <$ty>::BITS as usize;
+        }
+
+        impl<const N: usize> BitLength for &[&$ty; N] {
+            const BITS: usize = N * <$ty>::BITS as usize;
         }
 
         impl GetBit<Lsb0> for $ty {


### PR DESCRIPTION
This PR implements the `BitLength` trait for `bool` and provides blanket implementations for arrays.