### PR TITLE
impl GetBit for Vec, remove ToBits impl for Vec<bool>

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -3,18 +3,15 @@ extern crate alloc;
 use alloc::vec::{IntoIter, Vec};
 use core::iter::FlatMap;
 
-use crate::{BitIter, BitLength, FromBits, GetBit, IntoBits, Lsb0, Msb0, ToBits};
+use crate::{BitIter, BitLength, BitOrder, FromBits, GetBit, IntoBits, Lsb0, Msb0};
 
-impl<'a> ToBits<'a> for Vec<bool> {
-    type IterLsb0 = core::iter::Copied<core::slice::Iter<'a, bool>>;
-    type IterMsb0 = core::iter::Copied<core::slice::Iter<'a, bool>>;
-
-    fn iter_lsb0(&'a self) -> Self::IterLsb0 {
-        self.iter().copied()
-    }
-
-    fn iter_msb0(&'a self) -> Self::IterMsb0 {
-        self.iter().copied()
+impl<T, O> GetBit<O> for Vec<T>
+where
+    T: GetBit<O> + BitLength,
+    O: BitOrder,
+{
+    fn get_bit(&self, index: usize) -> bool {
+        self[index / T::BITS].get_bit(index % T::BITS)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,13 @@ mod tests {
     }
 
     #[rstest]
+    fn test_to_bit_iter_boolvec() {
+        let bits = vec![false, true, false, true, false, true, false, true];
+
+        assert_eq!(u8::from_lsb0(bits.iter_lsb0()), 0b10101010);
+    }
+
+    #[rstest]
     #[case::u8(PhantomData::<u8>)]
     #[case::u16(PhantomData::<u16>)]
     #[case::u32(PhantomData::<u32>)]


### PR DESCRIPTION
This PR implements `GetBit` for `Vec<T>`, and also removes the explicit `ToBits` impl for `Vec<bool>` because `Vec<T>` can be coerced to `[T]`